### PR TITLE
Fix ltePrecise, which was implemented as less than, not less than or equal to.

### DIFF
--- a/source/services/Fable-Service-Math.js
+++ b/source/services/Fable-Service-Math.js
@@ -207,7 +207,7 @@ class FableServiceMath extends libFableServiceBase
 		let tmpRightValue = isNaN(pRightValue) ? 0 : pRightValue;
 
 		let tmpLeftArbitraryValue = new this.fable.Utility.bigNumber(tmpLeftValue);
-		return tmpLeftArbitraryValue.lt(tmpRightValue);
+		return tmpLeftArbitraryValue.lte(tmpRightValue);
 	}
 }
 

--- a/test/Math_test.js
+++ b/test/Math_test.js
@@ -51,7 +51,21 @@ suite
 
 						Expect(testFable.Math.gtPrecise(4, 5)).to.equal(false);
 						Expect(testFable.Math.gtePrecise(1000, 5)).to.equal(true);
+						Expect(testFable.Math.gtePrecise('0.00', '0.0')).to.equal(true);
+						Expect(testFable.Math.gtePrecise('0.00', '0.0000000000000000000000000000000001')).to.equal(false);
+						Expect(testFable.Math.gtePrecise('0.00', 0.01)).to.equal(false);
+						Expect(testFable.Math.gtePrecise('0.00', '-0.0000000000000000000000000000000001')).to.equal(true);
+						Expect(testFable.Math.gtePrecise('0.00', -0.01)).to.equal(true);
+						Expect(testFable.Math.gtePrecise('0.00000000000000000000000000000000099', '0.000000000000000000000000000000001')).to.equal(false);
+						Expect(testFable.Math.gtePrecise('0.000000000000000000000000000000001', '0.00000000000000000000000000000000099')).to.equal(true);
 						Expect(testFable.Math.ltePrecise(1000, 5)).to.equal(false);
+						Expect(testFable.Math.ltePrecise('0.00', '0.0')).to.equal(true);
+						Expect(testFable.Math.ltePrecise('0.00', '0.0000000000000000000000000000000001')).to.equal(true);
+						Expect(testFable.Math.ltePrecise('0.00', 0.01)).to.equal(true);
+						Expect(testFable.Math.ltePrecise('0.00', '-0.0000000000000000000000000000000001')).to.equal(false);
+						Expect(testFable.Math.ltePrecise('0.00', -0.01)).to.equal(false);
+						Expect(testFable.Math.ltePrecise('0.00000000000000000000000000000000099', '0.000000000000000000000000000000001')).to.equal(true);
+						Expect(testFable.Math.ltePrecise('0.000000000000000000000000000000001', '0.00000000000000000000000000000000099')).to.equal(false);
 						Expect(testFable.Math.ltPrecise(4, 5)).to.equal(true);
 
 						Expect(testFable.Math.comparePrecise(4, 5)).to.equal(-1);


### PR DESCRIPTION
* Added tests, and propagated them to `gtePrecise` for parity.
* Quick audit of other methods; looked ok.
* Ran math tests.

```bash
alex@ganondorf:~/dev/fable (=) % npm run tests Math

> fable@3.0.119 tests
> ./node_modules/mocha/bin/_mocha -u tdd --exit -R spec --grep Math



  Math
    Math Operations
      ✔ Exercise Math Tests
2024-05-10T00:44:01.467Z [warn] (ApplicationNameHere): Error parsing number (type undefined): Error: [big.js] Invalid number
      ✔ Parse Numbers
      ✔ Round Numbers
      ✔ Cast To Fixed Numbers


  4 passing (15ms)
```
